### PR TITLE
Feature/restrict package management

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+engine-strict=true
 legacy-peer-deps=true

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/README.md
+++ b/README.md
@@ -286,6 +286,12 @@ Once executed, the types will be generated. Endpoints can be accessed by importi
 
 <b>Important:</b> You cannot make any changes to files inside the `lib/swagger` directory because they will be overwritten the next time the swagger command is executed.
 
+## Package Management
+
+By default, Seasoning enforces the use of `npm` for package management, restricting other managers from being used. This is to ensure that all developers are using the same package versions, and to avoid any potential issues with package lock files.
+
+If your team would like to opt for another package manager, please update the engine lock requirements in the `package.json` file.
+
 ## strict Mode
 
 Using React's default configuration, strict mode is enabled in development mode to detect potential problems in the application.

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Once executed, the types will be generated. Endpoints can be accessed by importi
 
 ## Package Management
 
-By default, Seasoning enforces the use of `npm` for package management, restricting other managers from being used. This is to ensure that all developers are using the same package versions, and to avoid any potential issues with package lock files.
+By default, Seasoning enforces the use of `npm` for package management, restricting other managers from being used. This is to ensure that all developers are using the same package manager, and to avoid any potential issues with package lock files.
 
 If your team would like to opt for another package manager, please update the engine lock requirements in the `package.json` file.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "broth",
+  "name": "seasoning",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "broth",
+      "name": "seasoning",
       "version": "0.0.1",
       "dependencies": {
         "@date-io/dayjs": "^2.14.0",
@@ -93,6 +93,13 @@
         "tsconfig-paths-webpack-plugin": "^4.0.0",
         "typescript": "<4.8.0",
         "webpack": "^5.68.0"
+      },
+      "engines": {
+        "node": ">=14.17.0",
+        "npm": ">=6.14.13",
+        "pn": "please use npm",
+        "pnpm": "please use npm",
+        "yarn": "please use npm"
       }
     },
     "node_modules/@a110/storybook-expand-all": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
-  "name": "broth",
+  "name": "seasoning",
   "version": "0.0.1",
   "private": true,
+  "engines": {
+    "node": ">=14.17.0",
+    "npm": ">=6.14.13",
+    "yarn": "please use npm",
+    "pnpm": "please use npm",
+    "pn": "please use npm"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "test & lint & next build",


### PR DESCRIPTION
### Description

Restrict project to only npm as the package manager. 
Gives error if users attempt to use yarn, pnpm, or pn