### PR TITLE
fix: temporarily disable version bump

### DIFF
--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -1,35 +1,35 @@
-name: 'Semantic Version Bump'
+# name: 'Semantic Version Bump'
 
-on:
-  push:
-    branches:
-      - main
-      - master
-      - develop
-jobs:
-  bump-version:
-    name: 'Bump Version on main'
-    runs-on: ubuntu-latest
+# on:
+#   push:
+#     branches:
+#       - main
+#       - master
+#       - develop
+# jobs:
+#   bump-version:
+#     name: 'Bump Version on main'
+#     runs-on: ubuntu-latest
 
-    steps:
-      - name: 'Checkout source code'
-        uses: 'actions/checkout@v2'
-        with:
-          ref: ${{ github.ref }}
-      - name: 'cat package.json'
-        run: cat ./package.json
-      - name: 'Automated Version Bump'
-        id: version-bump
-        uses: 'phips28/gh-action-bump-version@master'
-        with:
-          tag-prefix: 'v'
-          major-wording: 'BREAKING CHANGE,MAJOR'
-          minor-wording: 'feat,MINOR'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: 'cat package.json'
-        run: cat ./package.json
-      - name: 'Output Step'
-        env:
-          NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
-        run: echo "new tag created -  $NEW_TAG"
+#     steps:
+#       - name: 'Checkout source code'
+#         uses: 'actions/checkout@v2'
+#         with:
+#           ref: ${{ github.ref }}
+#       - name: 'cat package.json'
+#         run: cat ./package.json
+#       - name: 'Automated Version Bump'
+#         id: version-bump
+#         uses: 'phips28/gh-action-bump-version@master'
+#         with:
+#           tag-prefix: 'v'
+#           major-wording: 'BREAKING CHANGE,MAJOR'
+#           minor-wording: 'feat,MINOR'
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#       - name: 'cat package.json'
+#         run: cat ./package.json
+#       - name: 'Output Step'
+#         env:
+#           NEW_TAG: ${{ steps.version-bump.outputs.newTag }}
+#         run: echo "new tag created -  $NEW_TAG"


### PR DESCRIPTION
### Description

Disabling version bump feature temporarily. 
Found that its a limitation with github-actions bot for protected branches: 
https://github.com/orgs/community/discussions/25305?sort=top